### PR TITLE
Clearer message when attempting to solve before locks are generated

### DIFF
--- a/contracts/bounty-contracts/order-finding-bounty/OrderFindingBounty.sol
+++ b/contracts/bounty-contracts/order-finding-bounty/OrderFindingBounty.sol
@@ -11,6 +11,7 @@ abstract contract OrderFindingBounty is BountyContract {
 
   function _verifySolution(uint256 lockNumber, bytes memory solution) internal view override returns (bool) {
     bytes[] memory lock = getLockValue(lockNumber);
+    require(lock.length > 0, 'Lock has not been generated yet.');
     bytes memory modulus = lock[0];
     bytes memory base = lock[1];
 

--- a/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingAccumulator.sol
+++ b/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingAccumulator.sol
@@ -76,6 +76,6 @@ contract OrderFindingAccumulator is OrderFindingBounty {
   }
 
   function _resetBytes() private {
-    currentBytes = "";
+    currentBytes = '';
   }
 }

--- a/test/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/order-finding-bounty-with-lock-generation.test.ts
+++ b/test/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/order-finding-bounty-with-lock-generation.test.ts
@@ -4,6 +4,7 @@ import {
 import { ethers } from 'hardhat'
 import { expect } from 'chai'
 import { BigNumber } from 'ethers'
+import { submitSolution } from '../../bounty-utils'
 
 const MAX_GAS_LIMIT_OPTION = { gasLimit: BigNumber.from('0x1c9c380') }
 
@@ -17,6 +18,16 @@ describe('OrderFindingBountyWithLockGeneration', () => {
     }
     return bounty
   }
+
+  it('should not allow a solution if generation is incomplete', async () => {
+    const numberOfLocks = 1
+    const byteSizeOfModulus = 1
+    const bounty = await new OrderFindingBountyWithLockGeneration__factory(ethersSigner)
+      .deploy(numberOfLocks, byteSizeOfModulus)
+    const arbitrarySolution = '0x01'
+    const tx = submitSolution(0, arbitrarySolution, bounty)
+    await expect(tx).to.be.revertedWith('Lock has not been generated yet.')
+  })
 
   it('should revert lock generation if already done', async () => {
     const numberOfLocks = 1


### PR DESCRIPTION
Previously, attempting to solve the bounty before the locks were generated would result in a IndexOutOfBounds error. This reverts with a more descriptive message.