### PR TITLE
Quantum bounty customizable gcd iterations

### DIFF
--- a/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingAccumulator.sol
+++ b/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingAccumulator.sol
@@ -76,10 +76,12 @@ library OrderFindingAccumulator {
   /* Adapted rom https://gist.github.com/3esmit/8c0a63f17f2f2448cc1576eb27fe5910
    */
   function _isCoprime(Accumulator storage accumulator) private {
+    BigNumber memory a = accumulator._a;
+    BigNumber memory b = accumulator._b;
     for (uint256 i = 0; i < accumulator._gcdIterationsPerCall; i++) {
-      bool checkIsFinished = accumulator._b.isZero();
+      bool checkIsFinished = b.isZero();
       if (checkIsFinished) {
-        bool isCoprime = accumulator._a.eq(BigNumbers.one());
+        bool isCoprime = a.eq(BigNumbers.one());
         if (isCoprime) {
           accumulator.locks.vals[accumulator._currentLockNumber][1] = _slicePrefix(accumulator);
           ++accumulator._currentLockNumber;
@@ -88,11 +90,13 @@ library OrderFindingAccumulator {
         _resetBytes(accumulator);
         return;
       } else {
-        BigNumber memory temp = accumulator._b;
-        accumulator._b = accumulator._a.mod(accumulator._b);
-        accumulator._a = temp;
+        BigNumber memory temp = b;
+        b = a.mod(b);
+        a = temp;
       }
     }
+    accumulator._a = a;
+    accumulator._b = b;
   }
 
   function _slicePrefix(Accumulator storage accumulator) private view returns (bytes memory) {

--- a/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingAccumulatorTestHelper.sol
+++ b/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingAccumulatorTestHelper.sol
@@ -6,8 +6,8 @@ import "./OrderFindingAccumulator.sol";
 contract OrderFindingAccumulatorTestHelper {
   Accumulator public accumulator;
 
-  constructor(uint256 numberOfLocks, uint256 bytesPerPrime) {
-    accumulator = OrderFindingAccumulator.init(numberOfLocks, bytesPerPrime);
+  constructor(uint256 numberOfLocks, uint256 bytesPerPrime, uint256 gcdIterationsPerCall) {
+    accumulator = OrderFindingAccumulator.init(numberOfLocks, bytesPerPrime, gcdIterationsPerCall);
   }
 
   function triggerAccumulate(bytes memory randomBytes) public {

--- a/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingBountyWithLockGeneration.sol
+++ b/contracts/bounty-contracts/order-finding-bounty/order-finding-bounty-with-lock-generation/OrderFindingBountyWithLockGeneration.sol
@@ -10,10 +10,10 @@ contract OrderFindingBountyWithLockGeneration is OrderFindingBounty {
 
   Accumulator private orderFindingAccumulator;
 
-  constructor(uint256 numberOfLocks, uint256 byteSizeOfModulus)
+  constructor(uint256 numberOfLocks, uint256 byteSizeOfModulus, uint256 gcdIterationsPerCall)
     OrderFindingBounty(numberOfLocks)
   {
-    orderFindingAccumulator = OrderFindingAccumulator.init(numberOfLocks, byteSizeOfModulus);
+    orderFindingAccumulator = OrderFindingAccumulator.init(numberOfLocks, byteSizeOfModulus, gcdIterationsPerCall);
   }
 
   function locks() internal view override returns (Locks storage) {

--- a/deploy/6_deploy_order_finding_bounty.ts
+++ b/deploy/6_deploy_order_finding_bounty.ts
@@ -3,6 +3,7 @@ import { DeployFunction } from 'hardhat-deploy/types'
 import { Create2Factory } from '../src/Create2Factory'
 import { ethers } from 'hardhat'
 import { BigNumber } from 'ethers'
+import * as fs from 'fs'
 
 const MAX_GAS_LIMIT_OPTION = { gasLimit: BigNumber.from('0x1c9c380') }
 
@@ -13,8 +14,9 @@ const deployOrderFindingBounty: DeployFunction = async function (hre: HardhatRun
 
   const numberOfLocks = 119
   const byteSizeOfModulus = 128 * 3
-  const gcdIterationsPerCall = 2 ** 10
+  const gcdIterationsPerCall = 2 ** 9
   let gasUsed = BigNumber.from(0)
+  let maxGas = BigNumber.from(0)
   let numberOfAccumulations = 0
 
   const deployResult = await hre.deployments.deploy(
@@ -33,21 +35,25 @@ const deployOrderFindingBounty: DeployFunction = async function (hre: HardhatRun
     ++numberOfAccumulations
     const tx = await bounty.triggerLockAccumulation(MAX_GAS_LIMIT_OPTION)
     const receipt = await tx.wait()
-
-    if (await bounty.callStatic.isCheckingPrime()) {
-      while (await bounty.callStatic.isCheckingPrime()) {
-        console.log('_b: ', (await bounty.currentPrimeCheck()))
-        await bounty.triggerLockAccumulation(MAX_GAS_LIMIT_OPTION)
-      }
-    }
-
     gasUsed = gasUsed.add(receipt.gasUsed)
+    if (receipt.gasUsed.gt(maxGas)) maxGas = receipt.gasUsed
+
+    if (await bounty.callStatic.isCheckingPrime()) console.log('_b: ', (await bounty.currentPrimeCheck()))
   }
+
   console.log('==OrderFindingBounty gasUsed=', gasUsed.toHexString())
+  console.log('==OrderFindingBounty maxGas=', maxGas.toHexString())
   const [modulus, base] = await bounty.getLock(0)
   console.log('Modulus: ', modulus)
   console.log('Base: ', base)
   console.log(`Number of accumulations: ${numberOfAccumulations}`)
+
+  fs.writeFile(
+    'Output.txt',
+    `gasUsed: ${gasUsed.toHexString()};\n\nMax Gas: ${maxGas.toHexString()};\n\nModulus: ${modulus as string};\n\nBase: ${base as string};\n\nNumber of Accumulations: ${numberOfAccumulations}`,
+    (err) => {
+      if (err != null) throw err
+    })
 }
 
 module.exports = deployOrderFindingBounty

--- a/deploy/6_deploy_order_finding_bounty.ts
+++ b/deploy/6_deploy_order_finding_bounty.ts
@@ -14,7 +14,7 @@ const deployOrderFindingBounty: DeployFunction = async function (hre: HardhatRun
 
   const numberOfLocks = 119
   const byteSizeOfModulus = 128 * 3
-  const gcdIterationsPerCall = 2 ** 9
+  const gcdIterationsPerCall = 2 ** 11
   let gasUsed = BigNumber.from(0)
   let maxGas = BigNumber.from(0)
   let numberOfAccumulations = 0

--- a/deploy/6_deploy_order_finding_bounty.ts
+++ b/deploy/6_deploy_order_finding_bounty.ts
@@ -13,6 +13,7 @@ const deployOrderFindingBounty: DeployFunction = async function (hre: HardhatRun
 
   const numberOfLocks = 119
   const byteSizeOfModulus = 128 * 3
+  const gcdIterationsPerCall = 2 ** 10
   let gasUsed = BigNumber.from(0)
   let numberOfAccumulations = 0
 
@@ -20,7 +21,7 @@ const deployOrderFindingBounty: DeployFunction = async function (hre: HardhatRun
     'OrderFindingBountyWithLockGeneration', {
       ...MAX_GAS_LIMIT_OPTION,
       from,
-      args: [numberOfLocks, byteSizeOfModulus],
+      args: [numberOfLocks, byteSizeOfModulus, gcdIterationsPerCall],
       gasLimit: 6e6,
       deterministicDeployment: true
     })


### PR DESCRIPTION
This adds a parameter to set the number of iterations done in one trigger to find the GCD of a base and modulus. This allows customization of gas cost per call when generating the puzzle.